### PR TITLE
handle empty environment properly

### DIFF
--- a/source/all/cw32.asm
+++ b/source/all/cw32.asm
@@ -4219,10 +4219,14 @@ GetEXECName     proc    near
         inc     si              ;/
         or      al,al           ;End of a string?
         jnz     @@1             ;keep looking.
-        mov     al,es:[si]              ;Double zero?
+        mov     al,es:[si]              ;Double zero or 1 0?
+        cmp     al,1
+        je      @@11
         or      al,al           ;/
         jnz     @@1             ;keep looking.
-        add     si,3            ;Skip last 0 and word count.
+        inc     si
+@@11:
+        add     si,2            ;Skip last 0 and word count.
         mov     di,offset MainExec
         mov     bx,_cwInit
         mov     fs,bx


### PR DESCRIPTION
Empty environment does not have 2 consequitive zeros because
one of these zeros is from previous ASCIZ env string, which is not there.
So look also for 0 1, in which case skip only 2 bytes instead of 3.

Note: there are lots of such code instances in api.asm.
But they do not execute for me so this patch does not touch them.
I don't know when they are executed.