### PR TITLE
properly handle open failure

### DIFF
--- a/source/all/cw32.asm
+++ b/source/all/cw32.asm
@@ -832,6 +832,7 @@ chk386:
 ;Retrieve setup info from 3P header.
 ;
         call    GetSystemFlags
+        jc      InitError
 ;
 ;Check if a suitable method for switching to protected mode exists.
 ;
@@ -4279,7 +4280,7 @@ GetSystemFlags  proc    near
         mov     cx,1bh          ;size of it.
         mov     ah,3fh
         int     21h
-        jc      @@4
+        jc      @@44
         cmp     ax,1bh          ;did we read right amount?
         jnz     @@4
         cmp     w[IExeSignature],'ZM'   ;Normal EXE?
@@ -4308,7 +4309,7 @@ medexe2:
         mov     cx,size NewHeaderStruc  ;size of it.
         mov     ah,3fh
         int     21h
-        jc      @@4
+        jc      @@44
         or      ax,ax           ;end of the file?
         jz      @@SetRUN
         cmp     ax,size NewHeaderStruc  ;did we read right amount?
@@ -4421,8 +4422,13 @@ medexe2:
 @@sr5:  pop     es
         ;
         assume ds:_cwMain
+        clc
 @@5:    pop     ds
         ret
+@@44:   mov     ax,3e00h
+        int     21h
+        stc
+        jmp     @@5
 GetSystemFlags  endp
 
 


### PR DESCRIPTION
Currently the failure to open itself (for reading flags from the 3P payload) causes this:
Exception: 0D, Error code: 0000
... and a write of a CW.ERR.

With this patch you'll see a somewhat cryptic
CauseWay error 04 : DOS 3.1 or better required.
... which is much better than the crash.

Fixes https://github.com/tkchia/causeway/issues/4