### PR TITLE
check env seg for NULL

### DIFF
--- a/source/all/cw32.asm
+++ b/source/all/cw32.asm
@@ -789,6 +789,9 @@ ENDIF
 ;
         mov     RealPSPSegment,es
         mov     ax,es:w[02ch]
+        mov     cs:IErrorNumber,10
+        test    ax,ax                   ;NULL env pointer?
+        jz      toiniterr
         mov     RealEnvSegment,ax       ;Stow ENV for later.
 ;
 ;Re-size memory so we can allocate what we want high.


### PR DESCRIPTION
Some DOSes set env seg to NULL, either when env is empty or always for the first process (aka permanent shell).
This patch is trying to gracefully shut down in that case. Unfortunately, gracefully terminating the initial process is not always possible, but at least you will see a proper error msg before hang or a junk output. :)